### PR TITLE
change identitydb to IdentityConnection

### DIFF
--- a/MvcMusicStore/Web.config
+++ b/MvcMusicStore/Web.config
@@ -18,7 +18,7 @@
   </appSettings>
   <connectionStrings>
     <add name="MusicStoreEntities" connectionString="Data Source=.;Initial Catalog=MusicStore;Integrated Security=SSPI" providerName="System.Data.SqlClient"/>
-    <add name="identitydb" connectionString="Data Source=.;Initial Catalog=Identity;Integrated Security=SSPI" providerName="System.Data.SqlClient"/>
+    <add name="IdentityConnection" connectionString="Data Source=.;Initial Catalog=Identity;Integrated Security=SSPI" providerName="System.Data.SqlClient"/>
   </connectionStrings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -36,7 +36,7 @@
     <membership defaultProvider="AspNetSqlMembershipProvider">
       <providers>
         <clear/>
-        <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="identitydb"
+        <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="IdentityConnection"
           enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="true" applicationName="MvcMusicStore"
           requiresUniqueEmail="false" passwordFormat="Hashed"/>
       </providers>
@@ -44,14 +44,14 @@
     <profile>
       <providers>
         <clear/>
-        <add name="AspNetSqlProfileProvider" connectionStringName="identitydb" applicationName="MvcMusicStore" type="System.Web.Profile.SqlProfileProvider"/>
+        <add name="AspNetSqlProfileProvider" connectionStringName="IdentityConnection" applicationName="MvcMusicStore" type="System.Web.Profile.SqlProfileProvider"/>
       </providers>
     </profile>
     <!-- Configure the Sql Role Provider -->
     <roleManager enabled="true" defaultProvider="SqlRoleProvider">
       <providers>
         <clear/>
-        <add name="SqlRoleProvider" type="System.Web.Security.SqlRoleProvider" connectionStringName="identitydb" applicationName="MvcMusicStore"/>
+        <add name="SqlRoleProvider" type="System.Web.Security.SqlRoleProvider" connectionStringName="IdentityConnection" applicationName="MvcMusicStore"/>
       </providers>
     </roleManager>
     <pages controlRenderingCompatibilityVersion="4.0"/>


### PR DESCRIPTION
Change identitydb to IdentityConnection in Web.config to align the connection string naming with the other branches


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
